### PR TITLE
Avoid loading bitsandbytes when not quantizing models

### DIFF
--- a/src/dendron/actions/causal_lm_action.py
+++ b/src/dendron/actions/causal_lm_action.py
@@ -149,7 +149,7 @@ class CausalLMAction(ActionNode):
             case False, True:
                 self.bnb_cfg.load_in_8bit = True
             case False, False:
-                pass
+                self.bnb_cfg = None
 
         if cfg.use_flash_attn_2:
             self.attn_implementation = "flash_attention_2"


### PR DESCRIPTION
This fixes the issue of a model factory checking that bitsandbytes and cuda are available even in cases where we are not loading a quantized model. This solves the problem described in #1 